### PR TITLE
Switch from GitHub releases to GitHub tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Principle
 
 For each package, the upstream URL and/or source URL is matched against supported platforms. For those platforms the latest release is obtained via an API/HTTP call.
 
-* `github.com` or `github.io` → http://api.github.com/repos/…/…/releases/latest (provide a [personal access token](https://github.com/settings/tokens) in the environment variable `GITHUB_TOKEN` for [higher request limits](https://developer.github.com/v3/#rate-limiting))
+* `github.com` or `github.io` → http://api.github.com/repos/…/…/tags (provide a [personal access token](https://github.com/settings/tokens) in the environment variable `GITHUB_TOKEN` for [higher request limits](https://developer.github.com/v3/#rate-limiting))
 * `registry.npmjs.org` → https://registry.npmjs.org/-/package/…/dist-tags
 * `pypi.org` or `pypi.io` or `pypi.python.org` or `files.pythonhosted.org` → https://pypi.python.org/pypi/…/json
 * `search.cpan.org` or `search.mcpan.org` → https://fastapi.metacpan.org/v1/release/…

--- a/upstream/github_test.go
+++ b/upstream/github_test.go
@@ -10,21 +10,32 @@ import (
 
 func mockGitHub() *gock.Response {
 	return gock.New("https://api.github.com/").
-		Get("/repos/gogits/gogs/releases/latest").
+		Get("/repos/gogits/gogs/tags").
 		Reply(http.StatusOK).
 		SetHeader("Content-Type", "application/atom+xml").
 		BodyString(`
-			{
-				"url": "https://api.github.com/repos/gogits/gogs/releases/8625798",
-				"id": 8625798,
-				"tag_name": "v0.11.34",
-				"target_commitish": "master",
-				"name": "v0.11.34",
-				"draft": false,
-				"prerelease": false,
-				"created_at": "2017-11-22T19:46:14Z",
-				"published_at": "2017-11-22T19:52:48Z"
-			}			
+			[
+				{
+					"name": "v0.11.34",
+					"zipball_url": "https://api.github.com/repos/gogs/gogs/zipball/v0.11.34",
+					"tarball_url": "https://api.github.com/repos/gogs/gogs/tarball/v0.11.34",
+					"commit": {
+						"sha": "6f2347fc71f17b5703a9b1f383a2d3451f88b741",
+						"url": "https://api.github.com/repos/gogs/gogs/commits/6f2347fc71f17b5703a9b1f383a2d3451f88b741"
+					},
+					"node_id": "MDM6UmVmMTY3NTI2MjA6djAuMTEuMzQ="
+				},
+				{
+					"name": "v0.11.33",
+					"zipball_url": "https://api.github.com/repos/gogs/gogs/zipball/v0.11.33",
+					"tarball_url": "https://api.github.com/repos/gogs/gogs/tarball/v0.11.33",
+					"commit": {
+						"sha": "b752fe680811119954ccef051e6f3b3e2a04c2e8",
+						"url": "https://api.github.com/repos/gogs/gogs/commits/b752fe680811119954ccef051e6f3b3e2a04c2e8"
+					},
+					"node_id": "MDM6UmVmMTY3NTI2MjA6djAuMTEuMzM="
+				}
+			]
 			`)
 }
 


### PR DESCRIPTION
For me it enables version checking for more repos. And checking for both releases and tags is unnecessary as every release has a tag associated with it.

Should fix  #19