### PR TITLE
Trim `release/` from tag name and handle -bzr as VCS package

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func handlePackages(vcsPackages bool, packages []pkg.Pkg, err error) {
 	}
 	sort.Slice(packages, func(i, j int) bool { return strings.Compare(packages[i].Name(), packages[j].Name()) == -1 })
 	for _, pkg := range packages {
-		isVcsPackage := strings.HasSuffix(pkg.Name(), "-git") || strings.HasSuffix(pkg.Name(), "-hg") || strings.HasSuffix(pkg.Name(), "-svn")
+		isVcsPackage := strings.HasSuffix(pkg.Name(), "-bzr") || strings.HasSuffix(pkg.Name(), "-git") || strings.HasSuffix(pkg.Name(), "-hg") || strings.HasSuffix(pkg.Name(), "-svn")
 		if vcsPackages == isVcsPackage {
 			s := handlePackage(pkg)
 			if commandline.printJSON {

--- a/upstream/version.go
+++ b/upstream/version.go
@@ -16,6 +16,7 @@ type Version string
 // String returns a sanitized version string
 func (v Version) String() string {
 	s := string(v)
+	s = strings.TrimLeft(s, "release/")
 	s = strings.TrimLeft(s, "v")
 	return s
 }


### PR DESCRIPTION
I don't know if the `release/` change is good or if some regex should be used to strip prefixes

For VCS suffixes, the Arch wiki lists the following, so maybe they should also be added?

> Suffix pkgname with `-cvs`, `-svn`, `-hg`, `-darcs`, `-bzr`, `-git` etc. unless the package fetches a specific release.